### PR TITLE
完善deepai使用代理

### DIFF
--- a/internal/queue/deepai.go
+++ b/internal/queue/deepai.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"time"
+
 	"github.com/mylxsw/aidea-server/pkg/ai/deepai"
 	"github.com/mylxsw/aidea-server/pkg/ai/openai"
 	repo2 "github.com/mylxsw/aidea-server/pkg/repo"
 	"github.com/mylxsw/aidea-server/pkg/uploader"
 	"github.com/mylxsw/aidea-server/pkg/youdao"
-	"time"
 
 	"github.com/hibiken/asynq"
 	"github.com/mylxsw/asteria/log"
@@ -137,7 +138,7 @@ func BuildDeepAICompletionHandler(client *deepai.DeepAI, translator youdao.Trans
 		defer cancel()
 
 		// 上传图片到七牛云
-		tmpURL, err := up.UploadRemoteFile(ctx, res.OutputURL, int(payload.GetUID()), uploader.DefaultUploadExpireAfterDays, "png", false)
+		tmpURL, err := up.UploadRemoteFile(ctx, res.OutputURL, int(payload.GetUID()), uploader.DefaultUploadExpireAfterDays, "png", true)
 		if err != nil {
 			log.With(payload).Errorf("upload image to qiniu failed: %v", err)
 		} else {

--- a/internal/queue/image_colorization.go
+++ b/internal/queue/image_colorization.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
+	"time"
+
 	"github.com/mylxsw/aidea-server/pkg/ai/deepai"
 	repo2 "github.com/mylxsw/aidea-server/pkg/repo"
 	"github.com/mylxsw/aidea-server/pkg/uploader"
-	"path/filepath"
-	"time"
 
 	"github.com/hibiken/asynq"
 	"github.com/mylxsw/asteria/log"
@@ -142,7 +143,7 @@ func imageColorization(ctx context.Context, deepClient *deepai.DeepAI, up *uploa
 		return "", fmt.Errorf("图片超分辨率失败: %w", err)
 	}
 
-	uploaded, err := up.UploadRemoteFile(ctx, res.OutputURL, int(userID), uploader.DefaultUploadExpireAfterDays, filepath.Ext(res.OutputURL), false)
+	uploaded, err := up.UploadRemoteFile(ctx, res.OutputURL, int(userID), uploader.DefaultUploadExpireAfterDays, filepath.Ext(res.OutputURL), true)
 	if err != nil {
 		return "", fmt.Errorf("图片上传失败: %w", err)
 	}

--- a/internal/queue/image_upscale.go
+++ b/internal/queue/image_upscale.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/mylxsw/aidea-server/pkg/ai/deepai"
-	"github.com/mylxsw/aidea-server/pkg/ai/stabilityai"
-	repo2 "github.com/mylxsw/aidea-server/pkg/repo"
-	uploader2 "github.com/mylxsw/aidea-server/pkg/uploader"
 	"image"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/mylxsw/aidea-server/pkg/ai/deepai"
+	"github.com/mylxsw/aidea-server/pkg/ai/stabilityai"
+	repo2 "github.com/mylxsw/aidea-server/pkg/repo"
+	uploader2 "github.com/mylxsw/aidea-server/pkg/uploader"
 
 	"github.com/hibiken/asynq"
 	"github.com/mylxsw/asteria/log"
@@ -190,7 +191,7 @@ func upscaleByDeepAI(ctx context.Context, deepClient *deepai.DeepAI, up *uploade
 		return "", fmt.Errorf("图片超分辨率失败: %w", err)
 	}
 
-	uploaded, err := up.UploadRemoteFile(ctx, res.OutputURL, int(userID), uploader2.DefaultUploadExpireAfterDays, filepath.Ext(res.OutputURL), false)
+	uploaded, err := up.UploadRemoteFile(ctx, res.OutputURL, int(userID), uploader2.DefaultUploadExpireAfterDays, filepath.Ext(res.OutputURL), true)
 	if err != nil {
 		return "", fmt.Errorf("图片上传失败: %w", err)
 	}


### PR DESCRIPTION
1. 调整resty 代理的设置放到 DeepAI 对象创建方法中
2. 修改breakWall = true，使增加分辨率和上色走uploader的http client。