### PR TITLE
fix: 修复未设置prometheus token的情况下 随便输入token 便能获取监控指标的bug

### DIFF
--- a/server/provider.go
+++ b/server/provider.go
@@ -379,7 +379,7 @@ func (h PrometheusHandler) ServeHTTP(writer http.ResponseWriter, request *http.R
 	}
 
 	tokenStr := strings.TrimPrefix(authHeader, "Bearer ")
-	if h.token != "" && tokenStr != h.token {
+	if h.token == "" || (h.token != "" && tokenStr != h.token) {
 		writer.WriteHeader(http.StatusUnauthorized)
 		return
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved authorization token validation for the Prometheus metrics handler, allowing for easier access when no token is provided.
- **Chores**
	- Minor adjustments to comments and formatting for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->