### PR TITLE
新增 You.com Search API 作为助手联网搜索的可选引擎

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -524,12 +524,14 @@ minimax-api-key: ""
 minimax-group-id: ""
 
 ######## Search 配置 ########
-# 搜索引擎，支持 bigmodel/bocha-web/bocha-ai
+# 搜索引擎，支持 bigmodel/bocha-web/bocha-ai/youcom
 search-engine: bigmodel
 # BigModel 搜索 API Key
 bigmodel-search-api-key: ""
 # Bochaai 搜索 API Key
 bochaai-search-api-key: ""
+# You.com 搜索 API Key（默认读取环境变量 YDC_API_KEY）
+youcom-search-api-key: ""
 
 ######## Search Assistant 配置 ########
 # 搜索引擎助手，支持 bigmodel/bochaai

--- a/config/config.go
+++ b/config/config.go
@@ -340,6 +340,8 @@ type Config struct {
 	BigModelSearchAPIKey string `json:"bigmodel_search_api_key" yaml:"bigmodel_search_api_key"`
 	// Bochaai Search 配置
 	BochaaiSearchAPIKey string `json:"bochaai_search_api_key" yaml:"bochaai_search_api_key"`
+	// You.com Search 配置
+	YouComSearchAPIKey string `json:"youcom_search_api_key" yaml:"youcom_search_api_key"`
 	// Search Assistant 配置 (用于将用户的对话上下文转换为搜索查询
 	SearchAssistantModel   string `json:"search_assistant_model" yaml:"search_assistant_model"`
 	SearchAssistantAPIBase string `json:"search_assistant_api_base" yaml:"search_assistant_api_base"`
@@ -671,6 +673,7 @@ func Register(ins *app.App) {
 
 			BigModelSearchAPIKey:   ctx.String("bigmodel-search-api-key"),
 			BochaaiSearchAPIKey:    ctx.String("bochaai-search-api-key"),
+			YouComSearchAPIKey:     ctx.String("youcom-search-api-key"),
 			SearchEngine:           ctx.String("search-engine"),
 			AvailableSearchEngines: array.Uniq(append(ctx.StringSlice("available-search-engines"), ctx.String("search-engine"))),
 			SearchAssistantModel:   ctx.String("search-assistant-model"),

--- a/config/flag.go
+++ b/config/flag.go
@@ -264,7 +264,8 @@ func initCmdFlags(ins *app.App) {
 
 	ins.AddStringFlag("bigmodel-search-api-key", "", "BigModel 搜索 API Key")
 	ins.AddStringFlag("bochaai-search-api-key", "", "Bochaai 搜索 API Key")
-	ins.AddStringFlag("search-engine", "bigmodel", "搜索引擎，支持 bigmodel/bocha-web/bocha-ai")
+	ins.AddStringFlag("youcom-search-api-key", os.Getenv("YDC_API_KEY"), "You.com 搜索 API Key（默认读取环境变量 YDC_API_KEY）")
+	ins.AddStringFlag("search-engine", "bigmodel", "搜索引擎，支持 bigmodel/bocha-web/bocha-ai/youcom")
 	ins.AddStringSliceFlag("available-search-engines", []string{}, "可用的搜索引擎")
 	ins.AddStringFlag("search-assistant-model", "gpt-4o-mini", "搜索助手模型")
 	ins.AddStringFlag("search-assistant-api-base", "https://api.openai.com/v1", "搜索助手 API Base")

--- a/pkg/search/search.go
+++ b/pkg/search/search.go
@@ -83,6 +83,8 @@ func (s *searchEngine) Search(ctx context.Context, req *Request) (*Response, err
 		return NewBochaWebSearch(s.conf.BochaaiSearchAPIKey, s.assistant).Search(ctx, req)
 	case "bocha-ai":
 		return NewBochaAISearch(s.conf.BochaaiSearchAPIKey, s.assistant).Search(ctx, req)
+	case "youcom":
+		return NewYouComSearch(s.conf.YouComSearchAPIKey, s.assistant).Search(ctx, req)
 	default:
 	}
 

--- a/pkg/search/youcom.go
+++ b/pkg/search/youcom.go
@@ -1,0 +1,153 @@
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// youComDefaultBaseURL is the production You.com search endpoint.
+const youComDefaultBaseURL = "https://ydc-index.io/v1/search"
+
+// youComMaxErrorBodyRunes bounds how much of an error response body we echo
+// back, so a huge or malformed error page never floods logs/messages.
+const youComMaxErrorBodyRunes = 500
+
+type YouComSearch struct {
+	apiKey    string
+	assistant *SearchAssistant
+	baseURL   string
+}
+
+// NewYouComSearch creates a You.com web search provider using the production endpoint.
+func NewYouComSearch(apiKey string, assistant *SearchAssistant) *YouComSearch {
+	return newYouComSearchWithBaseURL(apiKey, assistant, youComDefaultBaseURL)
+}
+
+// newYouComSearchWithBaseURL allows tests to point the provider at a local httptest server.
+func newYouComSearchWithBaseURL(apiKey string, assistant *SearchAssistant, baseURL string) *YouComSearch {
+	return &YouComSearch{apiKey: apiKey, assistant: assistant, baseURL: baseURL}
+}
+
+func (y *YouComSearch) Search(ctx context.Context, req *Request) (*Response, error) {
+	keyword := req.Query
+	if y.assistant != nil && len(req.Histories) > 0 {
+		keyword, _ = y.assistant.GenerateSearchQuery(ctx, req.Query, req.Histories)
+	}
+
+	count := req.ResultCount
+	if count <= 0 {
+		count = 5
+	}
+	if count > 20 {
+		count = 20
+	}
+
+	query := url.Values{}
+	query.Set("query", keyword)
+	query.Set("count", fmt.Sprintf("%d", count))
+
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", y.baseURL+"?"+query.Encode(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	httpReq.Header.Set("X-API-Key", y.apiKey)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("error: status code %d, body: %s", resp.StatusCode, truncateRunes(string(respBody), youComMaxErrorBodyRunes))
+	}
+
+	var apiResp YouComSearchResponse
+	if err := json.Unmarshal(respBody, &apiResp); err != nil {
+		return nil, err
+	}
+
+	var documents []Document
+	index := 0
+	for _, result := range apiResp.Results.Web {
+		index++
+		documents = append(documents, Document{
+			Title:   result.Title,
+			Source:  result.URL,
+			Content: youComResultContent(result),
+			Index:   fmt.Sprintf("%d", index),
+		})
+	}
+	for _, result := range apiResp.Results.News {
+		index++
+		documents = append(documents, Document{
+			Title:   result.Title,
+			Source:  result.URL,
+			Content: youComResultContent(result),
+			Index:   fmt.Sprintf("%d", index),
+		})
+	}
+
+	return &Response{Documents: documents}, nil
+}
+
+// youComResultContent assembles the Document content from a result's
+// description and snippets, both of which are optional.
+func youComResultContent(result YouComSearchResult) string {
+	content := result.Description
+	if len(result.Snippets) > 0 {
+		snippets := ""
+		for i, snippet := range result.Snippets {
+			if i > 0 {
+				snippets += "\n"
+			}
+			snippets += snippet
+		}
+
+		if content != "" {
+			content += "\n" + snippets
+		} else {
+			content = snippets
+		}
+	}
+
+	return content
+}
+
+// truncateRunes truncates s to at most n runes, rune-safe (never splits a
+// multi-byte character in half).
+func truncateRunes(s string, n int) string {
+	runes := []rune(s)
+	if len(runes) <= n {
+		return s
+	}
+	return string(runes[:n])
+}
+
+type YouComSearchResponse struct {
+	Results YouComSearchResults `json:"results,omitempty"`
+}
+
+type YouComSearchResults struct {
+	Web  []YouComSearchResult `json:"web,omitempty"`
+	News []YouComSearchResult `json:"news,omitempty"`
+}
+
+type YouComSearchResult struct {
+	URL         string   `json:"url,omitempty"`
+	Title       string   `json:"title,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Snippets    []string `json:"snippets,omitempty"`
+}

--- a/pkg/search/youcom_test.go
+++ b/pkg/search/youcom_test.go
@@ -1,0 +1,324 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestYouComSearch_RequestConstruction(t *testing.T) {
+	var gotPath, gotAPIKey, gotQuery, gotCount string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAPIKey = r.Header.Get("X-API-Key")
+		gotQuery = r.URL.Query().Get("query")
+		gotCount = r.URL.Query().Get("count")
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"results":{"web":[]}}`)
+	}))
+	defer server.Close()
+
+	s := newYouComSearchWithBaseURL("test-api-key", nil, server.URL+"/v1/search")
+	req := Request{Query: "bitcoin price", ResultCount: 3}
+
+	if _, err := s.Search(context.Background(), &req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotPath != "/v1/search" {
+		t.Errorf("unexpected path: %s", gotPath)
+	}
+	if gotAPIKey != "test-api-key" {
+		t.Errorf("unexpected X-API-Key header: %s", gotAPIKey)
+	}
+	if gotQuery != "bitcoin price" {
+		t.Errorf("unexpected query param: %s", gotQuery)
+	}
+	if gotCount != "3" {
+		t.Errorf("unexpected count param: %s", gotCount)
+	}
+}
+
+func TestYouComSearch_ResultCountDefaultAndCap(t *testing.T) {
+	cases := []struct {
+		name        string
+		resultCount int
+		wantCount   string
+	}{
+		{"zero uses default", 0, "5"},
+		{"negative uses default", -1, "5"},
+		{"within range kept as-is", 10, "10"},
+		{"over cap clamped to 20", 100, "20"},
+		{"exactly cap kept as-is", 20, "20"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotCount string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotCount = r.URL.Query().Get("count")
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, `{"results":{"web":[]}}`)
+			}))
+			defer server.Close()
+
+			s := newYouComSearchWithBaseURL("key", nil, server.URL)
+			req := Request{Query: "q", ResultCount: tc.resultCount}
+			if _, err := s.Search(context.Background(), &req); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if gotCount != tc.wantCount {
+				t.Errorf("count = %s, want %s", gotCount, tc.wantCount)
+			}
+		})
+	}
+}
+
+func TestYouComSearch_MappingWebAndNews(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"results": {
+				"web": [
+					{"url":"https://example.com/1","title":"Web One","description":"desc one","snippets":["snip a","snip b"]},
+					{"url":"https://example.com/2","title":"Web Two","description":"desc two"}
+				],
+				"news": [
+					{"url":"https://news.example.com/1","title":"News One","snippets":["only snippet"]}
+				]
+			}
+		}`)
+	}))
+	defer server.Close()
+
+	s := newYouComSearchWithBaseURL("key", nil, server.URL)
+	resp, err := s.Search(context.Background(), &Request{Query: "q"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(resp.Documents) != 3 {
+		t.Fatalf("expected 3 documents, got %d", len(resp.Documents))
+	}
+
+	d0 := resp.Documents[0]
+	if d0.Title != "Web One" || d0.Source != "https://example.com/1" || d0.Index != "1" {
+		t.Errorf("unexpected doc 0: %+v", d0)
+	}
+	if d0.Content != "desc one\nsnip a\nsnip b" {
+		t.Errorf("unexpected content assembly for doc 0: %q", d0.Content)
+	}
+
+	d1 := resp.Documents[1]
+	if d1.Content != "desc two" {
+		t.Errorf("unexpected content for doc 1 (no snippets): %q", d1.Content)
+	}
+	if d1.Index != "2" {
+		t.Errorf("unexpected index for doc 1: %s", d1.Index)
+	}
+
+	// News is appended after web, and index numbering continues sequentially.
+	d2 := resp.Documents[2]
+	if d2.Title != "News One" || d2.Source != "https://news.example.com/1" {
+		t.Errorf("unexpected news doc: %+v", d2)
+	}
+	if d2.Index != "3" {
+		t.Errorf("unexpected index for news doc: %s", d2.Index)
+	}
+	if d2.Content != "only snippet" {
+		t.Errorf("unexpected content for news doc (description missing): %q", d2.Content)
+	}
+}
+
+func TestYouComSearch_NewsAbsent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"results":{"web":[{"url":"https://example.com","title":"T","description":"D"}]}}`)
+	}))
+	defer server.Close()
+
+	s := newYouComSearchWithBaseURL("key", nil, server.URL)
+	resp, err := s.Search(context.Background(), &Request{Query: "q"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(resp.Documents) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(resp.Documents))
+	}
+}
+
+func TestYouComSearch_OptionalFieldsAllMissing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"results":{"web":[{"url":"https://example.com","title":"T"}]}}`)
+	}))
+	defer server.Close()
+
+	s := newYouComSearchWithBaseURL("key", nil, server.URL)
+	resp, err := s.Search(context.Background(), &Request{Query: "q"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(resp.Documents) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(resp.Documents))
+	}
+	if resp.Documents[0].Content != "" {
+		t.Errorf("expected empty content when description/snippets missing, got %q", resp.Documents[0].Content)
+	}
+}
+
+func TestYouComSearch_EmptyResults(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"results":{}}`)
+	}))
+	defer server.Close()
+
+	s := newYouComSearchWithBaseURL("key", nil, server.URL)
+	resp, err := s.Search(context.Background(), &Request{Query: "q"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Documents) != 0 {
+		t.Errorf("expected 0 documents, got %d", len(resp.Documents))
+	}
+}
+
+func TestYouComSearch_ErrorStatusCodes(t *testing.T) {
+	cases := []struct {
+		status int
+		body   string
+	}{
+		{http.StatusUnauthorized, `{"error":"invalid api key"}`},
+		{http.StatusTooManyRequests, `{"error":"rate limited"}`},
+		{http.StatusInternalServerError, `{"error":"internal error"}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("status_%d", tc.status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+				fmt.Fprint(w, tc.body)
+			}))
+			defer server.Close()
+
+			s := newYouComSearchWithBaseURL("super-secret-key", nil, server.URL)
+			_, err := s.Search(context.Background(), &Request{Query: "q"})
+			if err == nil {
+				t.Fatalf("expected error for status %d, got nil", tc.status)
+			}
+			if !strings.Contains(err.Error(), fmt.Sprintf("%d", tc.status)) {
+				t.Errorf("expected error to mention status code %d, got: %v", tc.status, err)
+			}
+			if strings.Contains(err.Error(), "super-secret-key") {
+				t.Errorf("error message must never echo the API key: %v", err)
+			}
+		})
+	}
+}
+
+func TestYouComSearch_ErrorBodyTruncatedRuneSafe(t *testing.T) {
+	// Build a body longer than the truncation limit, using multi-byte runes
+	// near the truncation boundary to make sure we never split one in half.
+	huge := strings.Repeat("a", youComMaxErrorBodyRunes-1) + "中文超长错误信息用于测试截断" + strings.Repeat("b", 100)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, huge)
+	}))
+	defer server.Close()
+
+	s := newYouComSearchWithBaseURL("key", nil, server.URL)
+	_, err := s.Search(context.Background(), &Request{Query: "q"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	// Must not panic (rune-safe) and must not contain the full huge body.
+	if strings.Contains(err.Error(), strings.Repeat("b", 100)) {
+		t.Errorf("expected error body to be truncated, but full tail was present: %v", err)
+	}
+
+	// Confirm the string is valid UTF-8 (no split multi-byte rune).
+	if !isValidUTF8(err.Error()) {
+		t.Errorf("error message is not valid UTF-8, a rune was split: %q", err.Error())
+	}
+}
+
+func isValidUTF8(s string) bool {
+	for _, r := range s {
+		if r == '�' {
+			return false
+		}
+	}
+	return true
+}
+
+func TestYouComSearch_MalformedJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{not valid json`)
+	}))
+	defer server.Close()
+
+	s := newYouComSearchWithBaseURL("key", nil, server.URL)
+	_, err := s.Search(context.Background(), &Request{Query: "q"})
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+}
+
+func TestYouComSearch_Timeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"results":{"web":[]}}`)
+	}))
+	defer server.Close()
+
+	s := newYouComSearchWithBaseURL("key", nil, server.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	_, err := s.Search(ctx, &Request{Query: "q"})
+	if err == nil {
+		t.Fatal("expected a timeout error")
+	}
+}
+
+// TestYouComSearch_Search is the live integration test, mirroring the repo's
+// existing style (e.g. TestBochaWebSearch_Search): skipped cleanly when
+// YDC_API_KEY is not set, and makes exactly one real call otherwise.
+func TestYouComSearch_Search(t *testing.T) {
+	apiKey := os.Getenv("YDC_API_KEY")
+	if apiKey == "" {
+		t.Skip("YDC_API_KEY not set, skipping live You.com search test")
+	}
+
+	s := NewYouComSearch(apiKey, nil)
+
+	req := Request{
+		Query:       "现在比特币价格多少？",
+		ResultCount: 3,
+	}
+
+	resp, err := s.Search(context.Background(), &req)
+	if err != nil {
+		t.Fatalf("搜索失败: %v", err)
+	}
+
+	for _, doc := range resp.Documents {
+		fmt.Printf("source: %s, title: %s, content: %s\n-------------------\n", doc.Source, doc.Title, doc.Content)
+	}
+}


### PR DESCRIPTION
关联 Issue: https://github.com/mylxsw/aidea-server/issues/82

## 动机

为助手联网搜索新增 You.com Search API 引擎选项，作为 bigmodel / bocha-web / bocha-ai 之外的补充。纯增量改动，未配置时不影响任何现有功能。

## 变更内容

- 新增 `pkg/search/youcom.go` — `YouComSearch` 提供者，完全参照 `bocha_web.go` 的实现模式：复用 `SearchAssistant` 搜索词改写、`GET https://ydc-index.io/v1/search`（`X-API-Key` 认证）、结果映射为现有 `Document` 结构（网页 + 新闻双通道，`count` 默认 5、上限 20）
- `pkg/search/search.go` 调度器新增 `youcom` 分支
- 配置：`youcom_search_api_key`（flag `youcom-search-api-key`，默认读取环境变量 `YDC_API_KEY`，与 `leptonai-keys` 的既有写法一致）；`search-engine` 说明补充 youcom；`config.yaml` 示例同步更新
- 错误信息按现有风格（状态码 + 截断的响应体），截断按字符处理不会截断中文，API Key 不出现在任何错误信息中
- 新增 `pkg/search/youcom_test.go` — 10 个离线单元测试（httptest 模拟：请求构造、结果映射、数量默认/上限、401/429/500、异常 JSON、超时等）+ 1 个与现有测试风格一致的在线测试（未设置 `YDC_API_KEY` 时自动跳过）

## 测试方式

```bash
# 离线单元测试（无需 Key）
go test ./pkg/search/ -run YouCom -v

# 在线测试（需要 Key，仅 1 次真实调用；获取地址 https://you.com/platform/api-keys）
export YDC_API_KEY=<你的 Key>
go test ./pkg/search/ -run TestYouComSearch_Search -v
```

已实测：离线 10 个测试全部通过；在线测试返回真实结果（网页 + 新闻）；另通过真实 `config.Config{SearchEngine:"youcom"}` 构造 `NewSearcher` 验证了 配置 → 调度器 → 提供者 → 真实 API → Document 映射 的完整链路。`gofmt` / `go vet` / `go build ./...` 均通过。

## 备注

- 引擎默认不启用：仅当 `search-engine`（或请求的 `prefer_engine`）设置为 `youcom` 且配置了 Key 时生效，助手后端通过现有机制自动使用
- README 未包含搜索引擎相关文档，故未改动

---

**English summary**: Adds You.com Search API as a fourth assistant web-search engine, mirroring the existing bocha_web provider pattern: new pkg/search/youcom.go, one dispatcher case, youcom-search-api-key flag defaulting to the YDC_API_KEY env var, config.yaml sample updated. 10 offline unit tests + 1 env-gated live test. Purely additive and opt-in; verified end to end from config through dispatcher to live API.
